### PR TITLE
fix copy method which aliased the hash implementation

### DIFF
--- a/multihash.py
+++ b/multihash.py
@@ -66,7 +66,7 @@ class _Hash(object):
         initial substring.
         """
         clone = _Hash(self.known_hash)
-        clone.implem = self.implem
+        clone.implem = self.implem.copy()
         return clone
 
 

--- a/test.py
+++ b/test.py
@@ -50,5 +50,13 @@ class TestMultiHash(unittest.TestCase):
         self.assertEqual(multihash.blake2s().known_hash,
                          multihash.new('blake2s').known_hash)
 
+    def test_copy(self):
+        mh1 = multihash.new('sha3')
+        mh1.update(b'foo')
+        mh2 = mh1.copy()
+        self.assertEqual(mh1.hexdigest(), mh2.hexdigest())
+        mh2.update(b'bar')
+        self.assertNotEqual(mh1.hexdigest(), mh2.hexdigest())
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The copy() method created a new reference from the old hash implementation to the new one.

Test included.
